### PR TITLE
Fix to FluidContainerAssetResolver's getAssetData method

### DIFF
--- a/src/main/java/org/terasology/fluid/system/FluidContainerAssetResolver.java
+++ b/src/main/java/org/terasology/fluid/system/FluidContainerAssetResolver.java
@@ -95,12 +95,37 @@ public class FluidContainerAssetResolver implements AssetDataProducer<TextureDat
         }
         String[] split = assetName.split("\\(");
 
-        String[] parameters = split[1].substring(0, split[1].length() - 1).split(",");
+        // Get the parameters from the URN.
+        String[] parameters = null;
 
+        // If the URN's fragment name is non-empty, then that means this item is using a texture atlas.
+        // Thus, the necessary information is contained in the resource name (specifically split[1]) and fragment name.
+        if (!urn.getFragmentName().toString().equals("")) {
+            // Break up the string using commas.
+            parameters = urn.getFragmentName().toString().split(",");
+
+            // As this is a texture atlas, combine the location of the atlas (split[1]) with the name of the element in
+            // the atlas (parameters[0]), and store it back into parameters[0].
+            // Example: "woodandstone:items" + "#" + "WoodenBucket".
+            parameters[0] = split[1] + "#" + parameters[0];
+        }
+        // Otherwise, if the URN's fragment name is empty, then that means this item is using individual textures.
+        // Thus, all the necessary is contained in the resource name.
+        else
+        {
+            // First, remove everything up to and including the left parenthesis in the string, and then split it up
+            // using commas.
+            parameters = urn.getResourceName().toString().split("\\(")[1].split(",");
+        }
+
+        // If the number of parameters is less than 6, return with empty.
         if (parameters.length != 6) {
             logger.warn("Unexpected number of tokens when trying to getAssetData for a fluid container's content: {}", parameters);
             return Optional.empty();
         }
+
+        // Remove the extraneous right parenthesis from the end of the last parameter.
+        parameters[5] = parameters[5].substring(0, parameters[5].length() - 1);
 
         String textureWithHole = parameters[0];
         String fluidType = parameters[1];


### PR DESCRIPTION
# Description of Changes
## Modifications

In the FluidContainerAssetResolver's getAssetData method, I fixed the problem where due to a mistake of specifying the parameters, this method returned early with empty, therefore not updating the FluidContainer's texture to reflect that it had been filled. 

I also added a few conditionals to handle the situations where the FluidContainer textures could be either part of an atlas, or an individual texture image.
# How to Test

I strongly suggest downloading the "develop" branch of the WoodAndStone module, and use the "WoodenBucket"s there for testing.

Specifically:
- Create a world with module "WoodAndStone" and all its dependencies enabled.
- Once in the world, enter the command "giveItem WoodenBucket" into the command line several times to spawn multiple buckets.
- Walk to a water source.
- Once close to the water source, use the buckets on the water (be sure to be in the interaction range).
- The filled buckets should have their icon change to reflect that they are now filled. If this is the case, then the test is a success.

**Reference Image**:
![2016-06-06_084154](https://cloud.githubusercontent.com/assets/8609763/15828061/b38ff92e-2bc2-11e6-88e3-889aa8d350bf.png)
# Credits

I would like to thank @Cervator and @SkySom for helping me locate this issue.
