### PR TITLE
Fluid inventory slots can now be filled even if the inputted volume exceeds the total capacity.

### DIFF
--- a/src/main/java/org/terasology/fluid/component/FluidContainerItemComponent.java
+++ b/src/main/java/org/terasology/fluid/component/FluidContainerItemComponent.java
@@ -28,6 +28,7 @@ public class FluidContainerItemComponent implements Component, ItemDifferentiati
     @Replicate
     public String fluidType;
     public float volume;
+    public float maxVolume;
     public Vector2f fluidMinPerc;
     public Vector2f fluidSizePerc;
     public TextureRegionAsset<?> textureWithHole;

--- a/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
+++ b/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
@@ -42,6 +42,16 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
     @In
     private InventoryManager inventoryManager;
 
+    /**
+     * Fill up the provided fluid container item with the current fluid interacted with in the game world.
+     *
+     * @param event             The event which has details about how this entity was activated.
+     * @param item              The reference to the item being activated.
+     * @param fluidContainer    The component used for storing fluid in a container.
+     * @param itemComponent     A component included for filtering out non-matching events. Here, we only want entities
+     *                          which are used as items.
+     *
+     */
     @ReceiveEvent
     public void fillFluidContainerItem(ActivateEvent event, EntityRef item, FluidContainerItemComponent fluidContainer,
                                        ItemComponent itemComponent) {
@@ -59,6 +69,10 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
                         String fluidType = fluidRegistry.getFluidType(liquid.getType());
 
                         FluidUtils.setFluidForContainerItem(removedItem, fluidType);
+
+                        // Fill this fluid container up to max capacity.
+                        FluidContainerItemComponent container = removedItem.getComponent(FluidContainerItemComponent.class);
+                        container.volume = container.maxVolume;
 
                         if (!inventoryManager.giveItem(owner, event.getInstigator(), removedItem)) {
                             removedItem.destroy();

--- a/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
+++ b/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
@@ -68,11 +68,9 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
                     if (removedItem != null) {
                         String fluidType = fluidRegistry.getFluidType(liquid.getType());
 
-                        FluidUtils.setFluidForContainerItem(removedItem, fluidType);
-
-                        // Fill this fluid container up to max capacity.
-                        FluidContainerItemComponent container = removedItem.getComponent(FluidContainerItemComponent.class);
-                        container.volume = container.maxVolume;
+                        // Set the contents of this fluid container and fill it up to max capacity.
+                        FluidUtils.setFluidForContainerItem(removedItem, fluidType,
+                                removedItem.getComponent(FluidContainerItemComponent.class).maxVolume);
 
                         if (!inventoryManager.giveItem(owner, event.getInstigator(), removedItem)) {
                             removedItem.destroy();

--- a/src/main/java/org/terasology/fluid/system/FluidClientSystem.java
+++ b/src/main/java/org/terasology/fluid/system/FluidClientSystem.java
@@ -25,10 +25,10 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.fluid.component.FluidContainerItemComponent;
+import org.terasology.logic.common.DisplayNameComponent;
 import org.terasology.logic.inventory.ItemComponent;
 import org.terasology.registry.In;
 import org.terasology.rendering.assets.texture.Texture;
-
 import java.util.Optional;
 
 @RegisterSystem(RegisterMode.CLIENT)
@@ -64,12 +64,25 @@ public class FluidClientSystem extends BaseComponentSystem {
                             fluidContainerItem.fluidSizePerc.x, fluidContainerItem.fluidSizePerc.y);
                     Optional<Texture> icon = assetManager.getAsset(iconUrn, Texture.class);
                     itemComp.icon = icon.isPresent() ? icon.get() : fluidContainerItem.emptyTexture;
+
+                    // Update description with new fluid amounts.
+                    DisplayNameComponent displayName = container.getComponent(DisplayNameComponent.class);
+                    displayName.description = "This holds " + (int) fluidContainerItem.volume*1000 + "/" +
+                            (int) fluidContainerItem.maxVolume*1000 + " ml of " + fluidType + ".";
+
                     container.saveComponent(itemComp);
+                    container.saveComponent(displayName);
                 }
             } else {
                 ItemComponent itemComp = container.getComponent(ItemComponent.class);
                 itemComp.icon = fluidContainerItem.emptyTexture;
+
+                // Update description.
+                DisplayNameComponent displayName = container.getComponent(DisplayNameComponent.class);
+                displayName.description = "This holds no fluid.";
+
                 container.saveComponent(itemComp);
+                container.saveComponent(displayName);
             }
         }
     }

--- a/src/main/java/org/terasology/fluid/system/FluidManager.java
+++ b/src/main/java/org/terasology/fluid/system/FluidManager.java
@@ -18,13 +18,70 @@ package org.terasology.fluid.system;
 import org.terasology.entitySystem.entity.EntityRef;
 
 public interface FluidManager {
+    /**
+     * Add a certain volume of fluid to all fluid inventory slots.
+     *
+     * @param instigator    The entity that's instigating this action.
+     * @param container     The entity that houses the fluid inventory.
+     * @param fluidType     The type of fluid being added.
+     * @param volume        The volume of fluid being added.
+     */
     boolean addFluid(EntityRef instigator, EntityRef container, String fluidType, float volume);
 
+    /**
+     * Add a certain volume of fluid to a particular fluid inventory slot.
+     *
+     * @param instigator    The entity that's instigating this action.
+     * @param container     The entity that houses the fluid inventory.
+     * @param slot          The slot number of the fluid inventory that's intended to be filled.
+     * @param fluidType     The type of fluid being added.
+     * @param volume        The volume of fluid being added.
+     */
     boolean addFluid(EntityRef instigator, EntityRef container, int slot, String fluidType, float volume);
 
+    /**
+     * Add fluid to a particular fluid inventory slot from a fluid holder.
+     *
+     * @param instigator    The entity that's instigating this action.
+     * @param inventory     The entity that houses the fluid inventory.
+     * @param holder        The entity that houses the fluid holder that the fluid's being transferred from.
+     * @param slot          The slot number of the fluid inventory that's intended to be filled.
+     * @param fluidType     The type of fluid being added.
+     * @param volume        The volume of fluid being added.
+     */
+    boolean addFluidFromHolder(EntityRef instigator, EntityRef inventory, EntityRef holder, int slot, String fluidType, float volume);
+
+    /**
+     * Remove a certain volume of fluid from all fluid inventory slots.
+     *
+     * @param instigator    The entity that's instigating this action.
+     * @param container     The entity that houses the fluid inventory.
+     * @param fluidType     The type of fluid being added.
+     * @param volume        The volume of fluid being added.
+     */
     boolean removeFluid(EntityRef instigator, EntityRef container, String fluidType, float volume);
 
+    /**
+     * Remove a certain volume of fluid from a particular fluid inventory slot.
+     *
+     * @param instigator    The entity that's instigating this action.
+     * @param container     The entity that houses the fluid inventory.
+     * @param slot          The slot number of the fluid inventory that's intended to be used.
+     * @param fluidType     The type of fluid being removed.
+     * @param volume        The volume of fluid being removed.
+     */
     boolean removeFluid(EntityRef instigator, EntityRef container, int slot, String fluidType, float volume);
 
+    /**
+     * Transfer fluid from one fluid inventory slot to another.
+     *
+     * @param instigator    The entity that's instigating this action.
+     * @param from          The entity that houses the source fluid inventory.
+     * @param to            The entity that houses the destination fluid inventory.
+     * @param slotFrom      The slot number of the source fluid inventory that's intended to be used.
+     * @param fluidType     The type of fluid being transferred.
+     * @param slotTo        The slot number of the destination fluid inventory that's intended to be used.
+     * @param volume        The volume of fluid being transferred.
+     */
     float moveFluid(EntityRef instigator, EntityRef from, EntityRef to, int slotFrom, String fluidType, int slotTo, float volume);
 }

--- a/src/main/java/org/terasology/fluid/system/FluidUtils.java
+++ b/src/main/java/org/terasology/fluid/system/FluidUtils.java
@@ -46,6 +46,29 @@ public final class FluidUtils {
     }
 
     /**
+     * Sets the fluid type and the current volume of a fluid container.
+     *
+     * @param container     Reference to entity that houses the fluid container item.
+     * @param fluidType     Name of the fluid type.
+     * @param volume        The amount of fluid being set.
+     */
+    public static void setFluidForContainerItem(EntityRef container, String fluidType, float volume) {
+        FluidContainerItemComponent resultContainer = container.getComponent(FluidContainerItemComponent.class);
+        resultContainer.fluidType = fluidType;
+
+        // If the fluid type is set to null, empty the container.
+        if (fluidType == null) {
+            resultContainer.volume = 0;
+        }
+        // If it's not, set the volume of this container to the passed volume argument.
+        else {
+            resultContainer.volume = volume;
+        }
+
+        container.saveComponent(resultContainer);
+    }
+
+    /**
      * Get the fluid type of the fluid stored in this particular fluid inventory slot.
      *
      * @param entity        Reference to entity that houses the fluid inventory component.

--- a/src/main/java/org/terasology/fluid/system/FluidUtils.java
+++ b/src/main/java/org/terasology/fluid/system/FluidUtils.java
@@ -28,7 +28,7 @@ public final class FluidUtils {
     }
 
     /**
-     * Sets the fluid type of a fluid container.
+     * Sets the fluid type of a fluid container. This also fills the container up to capacity.
      *
      * @param container     Reference to entity that houses the fluid container item.
      * @param fluidType     Name of the fluid type.
@@ -40,6 +40,10 @@ public final class FluidUtils {
         // If the fluid type is set to null, empty the container.
         if (fluidType == null) {
             resultContainer.volume = 0;
+        }
+        else
+        {
+            resultContainer.volume = resultContainer.maxVolume;
         }
 
         container.saveComponent(resultContainer);

--- a/src/main/java/org/terasology/fluid/system/FluidUtils.java
+++ b/src/main/java/org/terasology/fluid/system/FluidUtils.java
@@ -20,16 +20,37 @@ import org.terasology.fluid.component.FluidComponent;
 import org.terasology.fluid.component.FluidContainerItemComponent;
 import org.terasology.fluid.component.FluidInventoryComponent;
 
+/**
+ * A set of utilities for managing fluids.
+ */
 public final class FluidUtils {
     private FluidUtils() {
     }
 
+    /**
+     * Sets the fluid type of a fluid container.
+     *
+     * @param container     Reference to entity that houses the fluid container item.
+     * @param fluidType     Name of the fluid type.
+     */
     public static void setFluidForContainerItem(EntityRef container, String fluidType) {
         FluidContainerItemComponent resultContainer = container.getComponent(FluidContainerItemComponent.class);
         resultContainer.fluidType = fluidType;
+
+        // If the fluid type is set to null, empty the container.
+        if (fluidType == null) {
+            resultContainer.volume = 0;
+        }
+
         container.saveComponent(resultContainer);
     }
 
+    /**
+     * Get the fluid type of the fluid stored in this particular fluid inventory slot.
+     *
+     * @param entity        Reference to entity that houses the fluid inventory component.
+     * @param slot          Slot number of the fluid inventory to access.
+     */
     public static String getFluidAt(EntityRef entity, int slot) {
         FluidInventoryComponent fluidInventoryComponent = entity.getComponent(FluidInventoryComponent.class);
         if (fluidInventoryComponent != null) {
@@ -43,6 +64,12 @@ public final class FluidUtils {
         return null;
     }
 
+    /**
+     * Get the volume of fluid stored in this particular fluid inventory slot.
+     *
+     * @param entity        Reference to entity that houses the fluid inventory component.
+     * @param slot          Slot number of the fluid inventory to access.
+     */
     public static float getFluidAmount(EntityRef entity, int slot) {
         FluidInventoryComponent fluidInventoryComponent = entity.getComponent(FluidInventoryComponent.class);
         if (fluidInventoryComponent != null) {
@@ -56,6 +83,11 @@ public final class FluidUtils {
         return 0;
     }
 
+    /**
+     * Get the number of slots present in this fluid inventory.
+     *
+     * @param entity        Reference to entity that houses the fluid inventory component.
+     */
     public static int getFluidSlotCount(EntityRef entity) {
         FluidInventoryComponent fluidInventoryComponent = entity.getComponent(FluidInventoryComponent.class);
         if (fluidInventoryComponent != null) {


### PR DESCRIPTION
### Description of changes

At a high level, what I did was make the FluidManager be able to allow fluid to be deposited into fluid inventory slots even if the combined total was greater than the max capacity. So now, you won't face the scenario where a CraftingStation has 9500/10000 ml of water, but you can't refill it as the wooden bucket has 10000 ml of water. Now, the former will be filled back up to max, and the latter (as long as you use the addFluidFromHolder method), will be drained down to 9500 ml.
### Other possible improvements

Add a description while mousing over the WoodenBuckets that shows their current volume and max capacity. For example, "5000 / 10000 ml".
### How to test

In a module like WoodAndStone or ThroughtTheAges, create a PortableHerbalismStation and a WoodenBucket. Fill the WoodenBucket with water, and deposit it into the fluid input slot of the station. The fluid meter should be below 10,000 ml. Then, craft any potion using the station. Refill the bucket again. Deposit it back into the fluid input slot of the station. The fluid meter should be refilled back up to 10,000 ml, and the bucket will still show the filled texture. If this is the case, the test is a success.
### Credits

@Cervator and @Josharias 
