### PR TITLE
Remove references to LiquidData from module

### DIFF
--- a/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
+++ b/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
@@ -18,8 +18,6 @@ package org.terasology.fluid.system;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
-import org.terasology.entitySystem.systems.RegisterMode;
-import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.fluid.component.FluidContainerItemComponent;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.inventory.InventoryManager;
@@ -28,12 +26,14 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
-import org.terasology.world.liquid.LiquidData;
 
 /**
  * This authority system handles how fluid items interact with the game world and how they are filled in containers.
+ * <p>
+ * It is currently unused pending a proper liquids module being made.
+ * Removed as a part of PR MovingBlocks/Terasology#3495
  */
-@RegisterSystem(RegisterMode.AUTHORITY)
+//@RegisterSystem(RegisterMode.AUTHORITY)
 public class FluidAuthoritySystem extends BaseComponentSystem {
     @In
     private WorldProvider worldProvider;
@@ -45,40 +45,40 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
     /**
      * Fill up the provided fluid container item with the current fluid interacted with in the game world.
      *
-     * @param event             The event which has details about how this entity was activated.
-     * @param item              The reference to the item being activated.
-     * @param fluidContainer    The component used for storing fluid in a container.
-     * @param itemComponent     A component included for filtering out non-matching events. Here, we only want entities
-     *                          which are used as items.
+     * @param event          The event which has details about how this entity was activated.
+     * @param item           The reference to the item being activated.
+     * @param fluidContainer The component used for storing fluid in a container.
+     * @param itemComponent  A component included for filtering out non-matching events. Here, we only want entities
+     *                       which are used as items.
      */
     @ReceiveEvent
     public void fillFluidContainerItem(ActivateEvent event, EntityRef item, FluidContainerItemComponent fluidContainer,
                                        ItemComponent itemComponent) {
-        if (fluidContainer.fluidType == null || fluidContainer.volume < fluidContainer.maxVolume) {
-            Vector3f location = event.getInstigatorLocation();
-            Vector3f direction = new Vector3f(event.getDirection());
-            direction.normalize();
-            for (int i = 0; i < 3; i++) {
-                location.add(direction);
-                LiquidData liquid = worldProvider.getLiquid(new Vector3i(location, 0.5f));
-                if (liquid != null && liquid.getType() != null && liquid.getDepth() > 0) {
-                    EntityRef owner = item.getOwner();
-                    final EntityRef removedItem = inventoryManager.removeItem(owner, event.getInstigator(), item, false, 1);
-                    if (removedItem != null) {
-                        String fluidType = fluidRegistry.getFluidType(liquid.getType());
-
-                        // Set the contents of this fluid container and fill it up to max capacity.
-                        FluidUtils.setFluidForContainerItem(removedItem, fluidType,
-                                removedItem.getComponent(FluidContainerItemComponent.class).maxVolume);
-
-                        if (!inventoryManager.giveItem(owner, event.getInstigator(), removedItem)) {
-                            removedItem.destroy();
-                        }
-                    }
-                    event.consume();
-                    return;
-                }
-            }
-        }
+//        if (fluidContainer.fluidType == null || fluidContainer.volume < fluidContainer.maxVolume) {
+//            Vector3f location = event.getInstigatorLocation();
+//            Vector3f direction = new Vector3f(event.getDirection());
+//            direction.normalize();
+//            for (int i = 0; i < 3; i++) {
+//                location.add(direction);
+//                LiquidData liquid = worldProvider.getLiquid(new Vector3i(location, 0.5f));
+//                if (liquid != null && liquid.getType() != null && liquid.getDepth() > 0) {
+//                    EntityRef owner = item.getOwner();
+//                    final EntityRef removedItem = inventoryManager.removeItem(owner, event.getInstigator(), item, false, 1);
+//                    if (removedItem != null) {
+//                        String fluidType = fluidRegistry.getFluidType(liquid.getType());
+//
+//                        // Set the contents of this fluid container and fill it up to max capacity.
+//                        FluidUtils.setFluidForContainerItem(removedItem, fluidType,
+//                                removedItem.getComponent(FluidContainerItemComponent.class).maxVolume);
+//
+//                        if (!inventoryManager.giveItem(owner, event.getInstigator(), removedItem)) {
+//                            removedItem.destroy();
+//                        }
+//                    }
+//                    event.consume();
+//                    return;
+//                }
+//            }
+//        }
     }
 }

--- a/src/main/java/org/terasology/fluid/system/FluidCommonSystem.java
+++ b/src/main/java/org/terasology/fluid/system/FluidCommonSystem.java
@@ -24,7 +24,6 @@ import org.terasology.registry.In;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.assets.texture.TextureUtil;
 import org.terasology.rendering.nui.Color;
-import org.terasology.world.liquid.LiquidType;
 
 /**
  * This system is used to initialize fluid systems at launch time.
@@ -45,6 +44,6 @@ public class FluidCommonSystem extends BaseComponentSystem {
         ResourceUrn waterTextureUri = TextureUtil.getTextureUriForColor(Color.BLUE);
         Texture texture = assetManager.getAsset(waterTextureUri, Texture.class).get();
 
-        fluidRegistry.registerFluid("Fluid:Water", new TextureFluidRenderer(texture, "water"), LiquidType.WATER);
+        fluidRegistry.registerFluid("Fluid:Water", new TextureFluidRenderer(texture, "water"));
     }
 }

--- a/src/main/java/org/terasology/fluid/system/FluidRegistry.java
+++ b/src/main/java/org/terasology/fluid/system/FluidRegistry.java
@@ -15,8 +15,6 @@
  */
 package org.terasology.fluid.system;
 
-import org.terasology.world.liquid.LiquidType;
-
 /**
  * A generic fluid registry interface.
  */
@@ -26,9 +24,8 @@ public interface FluidRegistry {
      *
      * @param fluidType     The type of fluid
      * @param fluidRenderer The fluid renderer
-     * @param liquidType    The liquid type associated with the fluid
      */
-    void registerFluid(String fluidType, FluidRenderer fluidRenderer, LiquidType liquidType);
+    void registerFluid(String fluidType, FluidRenderer fluidRenderer);
 
     /**
      * Accessor function which returns the list of fluid renderer associated with a given fluid type.
@@ -37,10 +34,4 @@ public interface FluidRegistry {
      */
     FluidRenderer getFluidRenderer(String fluidType);
 
-    /**
-     * Accessor function which returns the fluid type for a given liquid type.
-     *
-     * @param liquidType The liquid type
-     */
-    String getFluidType(LiquidType liquidType);
 }

--- a/src/main/java/org/terasology/fluid/system/FluidRegistryImpl.java
+++ b/src/main/java/org/terasology/fluid/system/FluidRegistryImpl.java
@@ -18,7 +18,6 @@ package org.terasology.fluid.system;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.registry.Share;
-import org.terasology.world.liquid.LiquidType;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,39 +29,24 @@ import java.util.Map;
 @Share(FluidRegistry.class)
 public class FluidRegistryImpl extends BaseComponentSystem implements FluidRegistry {
     private Map<String, FluidRenderer> fluidRenderers = new HashMap<>();
-    private Map<LiquidType, String> liquidMapping = new HashMap<>();
 
     /**
      * Registers the fluid with a given fluid renderer.
      *
      * @param fluidType     The type of fluid
      * @param fluidRenderer The fluid renderer
-     * @param liquidType    The liquid type associated with the fluid
      */
     @Override
-    public void registerFluid(String fluidType, FluidRenderer fluidRenderer, LiquidType liquidType) {
+    public void registerFluid(String fluidType, FluidRenderer fluidRenderer) {
         fluidRenderers.put(fluidType.toLowerCase(), fluidRenderer);
-        if (liquidType != null) {
-            liquidMapping.put(liquidType, fluidType.toLowerCase());
-        }
-    }
 
-    /**
-     * Accessor function which returns the fluid type for a given liquid type.
-     *
-     * @param liquidType The liquid type
-     * @return           The fluid type associated with it
-     */
-    @Override
-    public String getFluidType(LiquidType liquidType) {
-        return liquidMapping.get(liquidType);
     }
 
     /**
      * Accessor function which returns the list of fluid renderer associated with a given fluid type.
      *
      * @param fluidType The fluid type
-     * @return          The fluid renderer associated with the fluid type
+     * @return The fluid renderer associated with the fluid type
      */
     @Override
     public FluidRenderer getFluidRenderer(String fluidType) {


### PR DESCRIPTION
This removes all references to LiquidData, and in doing so means that the module no longer supports interacting with in world liquids.
This should be considered a temporary fix and a long term solution would be to create or overhaul a module to provide functionality for in world liquids.

See PR MovingBlocks/Terasology#3495 for more details