### PR TITLE
Changing filling mode of fluid containers to incremental

### DIFF
--- a/src/main/java/org/terasology/fluid/component/FluidContainerItemComponent.java
+++ b/src/main/java/org/terasology/fluid/component/FluidContainerItemComponent.java
@@ -36,6 +36,9 @@ public class FluidContainerItemComponent implements Component, ItemDifferentiati
     /** The maximum volume of fluid that the container can contain */
     public float maxVolume;
 
+    /** The volume of liquid added to the container in one click */
+    public float fillingAmount;
+
     /** The coordinate where the fluid 'filling' should start */
     public Vector2f fluidMinPerc;
 

--- a/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
+++ b/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
@@ -92,7 +92,7 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
      * @param itemComponent  A component included for filtering out non-matching events. Here, we only want entities
      *                       which are used as items.
      */
-    @ReceiveEvent(priority= EventPriority.PRIORITY_HIGH)
+    @ReceiveEvent(priority= EventPriority.PRIORITY_LOW + 10)
     public void fillFluidContainerItem(ActivateEvent event, EntityRef item, FluidContainerItemComponent fluidContainer,
                                        ItemComponent itemComponent) {
         if (fluidContainer.fluidType == null || fluidContainer.volume < fluidContainer.maxVolume) {

--- a/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
+++ b/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
@@ -100,11 +100,11 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
                 EntityRef owner = item.getOwner();
                 final EntityRef removedItem = inventoryManager.removeItem(owner, event.getInstigator(), item, false, 1);
                 //TODO: replace with better fluid handling, maybe by new CoreFluids module
+                FluidContainerItemComponent removedFluidContainer= removedItem.getComponent(FluidContainerItemComponent.class);
+                float volume= Math.min((removedFluidContainer.volume + removedFluidContainer.fillingAmount), removedFluidContainer.maxVolume);
                 if (removedItem != null && block.isWater()) {
-                    // Set the contents of this fluid container and fill it up to (current volume + filling amount).
-                    FluidUtils.setFluidForContainerItem(removedItem, "Fluid:Water",
-                            removedItem.getComponent(FluidContainerItemComponent.class).volume + removedItem.getComponent(FluidContainerItemComponent.class).fillingAmount);
-
+                    // Set the contents of this fluid container and fill it up to (current volume + filling amount) or maxVolume whichever is less.
+                    FluidUtils.setFluidForContainerItem(removedItem, "Fluid:Water", volume);
                     if (!inventoryManager.giveItem(owner, event.getInstigator(), removedItem)) {
                         removedItem.destroy();
                     }

--- a/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
+++ b/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
@@ -18,6 +18,7 @@ package org.terasology.fluid.system;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
@@ -91,7 +92,7 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
      * @param itemComponent  A component included for filtering out non-matching events. Here, we only want entities
      *                       which are used as items.
      */
-    @ReceiveEvent
+    @ReceiveEvent(priority= EventPriority.PRIORITY_HIGH)
     public void fillFluidContainerItem(ActivateEvent event, EntityRef item, FluidContainerItemComponent fluidContainer,
                                        ItemComponent itemComponent) {
         if (fluidContainer.fluidType == null || fluidContainer.volume < fluidContainer.maxVolume) {
@@ -100,9 +101,9 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
                 final EntityRef removedItem = inventoryManager.removeItem(owner, event.getInstigator(), item, false, 1);
                 //TODO: replace with better fluid handling, maybe by new CoreFluids module
                 if (removedItem != null && block.isWater()) {
-                    // Set the contents of this fluid container and fill it up to max capacity.
+                    // Set the contents of this fluid container and fill it up to (current volume + filling amount).
                     FluidUtils.setFluidForContainerItem(removedItem, "Fluid:Water",
-                            removedItem.getComponent(FluidContainerItemComponent.class).maxVolume);
+                            removedItem.getComponent(FluidContainerItemComponent.class).volume + removedItem.getComponent(FluidContainerItemComponent.class).fillingAmount);
 
                     if (!inventoryManager.giveItem(owner, event.getInstigator(), removedItem)) {
                         removedItem.destroy();

--- a/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
+++ b/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
@@ -103,7 +103,6 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
                 final EntityRef removedItem = inventoryManager.removeItem(owner, event.getInstigator(), item, false, 1);
                 //TODO: replace with better fluid handling, maybe by new CoreFluids module
                 FluidContainerItemComponent removedFluidContainer= removedItem.getComponent(FluidContainerItemComponent.class);
-<<<<<<< HEAD
                 if(removedFluidContainer.fillingAmount == 0) {                                // not defined
                     removedFluidContainer.fillingAmount = removedFluidContainer.maxVolume;
                 }
@@ -112,12 +111,6 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
                     // Set the contents of this fluid container and fill it up to (current volume + filling amount).
                     FluidUtils.setFluidForContainerItem(removedItem, "Fluid:Water", volume);
                     owner2.send(new ChatMessageEvent("Fluid container filled to volume: "+ volume + " / " + removedFluidContainer.maxVolume + " ml.", owner2));
-=======
-                float volume= Math.min((removedFluidContainer.volume + removedFluidContainer.fillingAmount), removedFluidContainer.maxVolume);
-                if (removedItem != null && block.isWater()) {
-                    // Set the contents of this fluid container and fill it up to (current volume + filling amount) or maxVolume whichever is less.
-                    FluidUtils.setFluidForContainerItem(removedItem, "Fluid:Water", volume);
->>>>>>> bd5cdf0abed95a19f29f979842d4798896c76a22
                     if (!inventoryManager.giveItem(owner, event.getInstigator(), removedItem)) {
                         removedItem.destroy();
                     }

--- a/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
+++ b/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
@@ -92,7 +92,7 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
      * @param itemComponent  A component included for filtering out non-matching events. Here, we only want entities
      *                       which are used as items.
      */
-    @ReceiveEvent(priority= EventPriority.PRIORITY_LOW + 10)
+    @ReceiveEvent
     public void fillFluidContainerItem(ActivateEvent event, EntityRef item, FluidContainerItemComponent fluidContainer,
                                        ItemComponent itemComponent) {
         if (fluidContainer.fluidType == null || fluidContainer.volume < fluidContainer.maxVolume) {

--- a/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
+++ b/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
@@ -18,7 +18,6 @@ package org.terasology.fluid.system;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
@@ -26,6 +25,7 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.fluid.component.FluidContainerItemComponent;
 import org.terasology.logic.chat.ChatMessageEvent;
 import org.terasology.logic.common.ActivateEvent;
+import org.terasology.logic.common.DisplayNameComponent;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.inventory.ItemComponent;
 import org.terasology.math.geom.Vector3f;
@@ -107,10 +107,11 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
                     removedFluidContainer.fillingAmount = removedFluidContainer.maxVolume;
                 }
                 float volume= Math.min((removedFluidContainer.volume + removedFluidContainer.fillingAmount), removedFluidContainer.maxVolume);
+                DisplayNameComponent displayNameComponent = item.getComponent(DisplayNameComponent.class);
                 if (removedItem != null && block.isWater()) {
                     // Set the contents of this fluid container and fill it up to (current volume + filling amount).
                     FluidUtils.setFluidForContainerItem(removedItem, "Fluid:Water", volume);
-                    owner2.send(new ChatMessageEvent("Fluid container filled to volume: "+ volume + " / " + removedFluidContainer.maxVolume + " ml.", owner2));
+                    owner2.send(new ChatMessageEvent( displayNameComponent.name + " filled to volume: "+ volume + " / " + removedFluidContainer.maxVolume + " ml.", owner2));
                     if (!inventoryManager.giveItem(owner, event.getInstigator(), removedItem)) {
                         removedItem.destroy();
                     }


### PR DESCRIPTION
Currently fluid containers are completely filled in a single click. With this PR, fluid containers will now be filled incrementally i.e. a certain small volume in each step.
Even though the filling of container has changed to incremental, the player does not receive a clear indication as to how much of the container is filled. Such an indicator needs to be added here. One simple way to do this is to send a chat message telling the player about the status of the volume of the fluid container after each step(of filling). An example can be found here:
https://github.com/Terasology/GooeysQuests/blob/master/src/main/java/org/terasology/gooeysQuests/GooeySpawnSystem.java#L193
I tried using the above example but was probably missing something so couldn't make it work. I received no error as such and the code was being executed however no message was being sent.  Readers are invited to take a go at the same if they wish to :)