### PR TITLE
Remove liquid from the world when filling container items.

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -5,7 +5,8 @@
     "displayName": "Fluid",
     "description": "This library module allows to manage fluids with items and containers.",
     "dependencies": [
-        { "id": "Inventory", "minVersion": "1.1.0" }
+        { "id": "Inventory", "minVersion": "1.1.0" },
+        { "id": "FlowingLiquids", "minVersion": "1.0.0" }
     ],
     "isServerSideOnly": false,
     "isLibrary": true

--- a/module.txt
+++ b/module.txt
@@ -6,7 +6,7 @@
     "description": "This library module allows to manage fluids with items and containers.",
     "dependencies": [
         { "id": "Inventory", "minVersion": "1.1.0" },
-        { "id": "FlowingLiquids", "minVersion": "1.0.0" }
+        { "id": "FlowingLiquids", "minVersion": "1.2.0" }
     ],
     "isServerSideOnly": false,
     "isLibrary": true

--- a/module.txt
+++ b/module.txt
@@ -6,7 +6,7 @@
     "description": "This library module allows to manage fluids with items and containers.",
     "dependencies": [
         { "id": "Inventory", "minVersion": "1.1.0" },
-        { "id": "FlowingLiquids", "minVersion": "1.2.0" }
+        { "id": "FlowingLiquids", "minVersion": "1.2.0", "optional": true }
     ],
     "isServerSideOnly": false,
     "isLibrary": true

--- a/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
+++ b/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
@@ -65,13 +65,17 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
     private ExtraBlockDataManager extraDataManager;
     private int flowIx;
     
-    private static final float fluidPerBlock = 1000;
+    /**
+     * If one block is 1m across, the fluid units are litres. This works reasonably
+     * sensibly with the pre-existing container sizes in ManualLabor.
+     */
+    private static final float FLUID_PER_BLOCK = 1000;
     private Random rand;
     
     @Override
     public void initialise() {
         air = blockManager.getBlock(BlockManager.AIR_ID);
-        flowIx = extraDataManager.getSlotNumber("flowingLiquids.flow");
+        flowIx = extraDataManager.getSlotNumber(LiquidData.EXTRA_DATA_NAME);
         rand = new Random();
     }
 
@@ -124,7 +128,7 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
                 //TODO: replace with better fluid handling, maybe by new CoreFluids module
                 if (removedItem != null && worldProvider.getBlock(pos).isWater()) {
                     byte liquidData = (byte) worldProvider.getExtraData(flowIx, pos);
-                    float blockAmount = LiquidData.getHeight(liquidData) * fluidPerBlock / LiquidData.MAX_HEIGHT;
+                    float blockAmount = LiquidData.getHeight(liquidData) * FLUID_PER_BLOCK / LiquidData.MAX_HEIGHT;
                     
                     FluidContainerItemComponent fluidComponent = removedItem.getComponent(FluidContainerItemComponent.class);
                     float totalAmount = blockAmount + fluidComponent.volume;
@@ -142,7 +146,7 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
                     }
                     
                     // This will be less than the original liquid height, unless the container somehow started off overfull.
-                    int liquidHeight = randomRound(blockAmount * LiquidData.MAX_HEIGHT / fluidPerBlock);
+                    int liquidHeight = randomRound(blockAmount * LiquidData.MAX_HEIGHT / FLUID_PER_BLOCK);
                     if (liquidHeight > 0) {
                         worldProvider.setExtraData(flowIx, pos, LiquidData.setHeight(liquidData, liquidHeight));
                     } else {
@@ -154,7 +158,7 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
         }
     }
     
-    // Round to an integer in a way that has 0 error on average for any given argument.
+    // Round randomly as either floor or ceiling in a way that has 0 error on average for any given argument.
     private int randomRound(float x) {
         return (int) Math.floor(x + rand.nextFloat());
     }


### PR DESCRIPTION
When filling fluid containers (like the cup and bucket) from water blocks, the amount of water in the block is depleted, and if there isn't enough water in the block to fill the container, it's only partially filled.

This adds a dependency on FlowingLiquids, as that contains the definition of liquid level in blocks. As a side-effect, this enables FlowingLiquids in Josharias Survival, and there's a bit of a problem with the interaction of FlowingLiquids and Caves (as the latter generates air-filled caves underwater, causing large amounts of liquid motion immediately after world generation).

I couldn't find an official definition of what the units of volume in this module are. I set the volume of liquid per full liquid block at 1000 (so the units are litres, assuming one block is 1m). This means that the cup and bucket from ManualLabor hold 0.3 and 0.5 blocks respectively. This seems like a sensible amount for the bucket to hold but an absurdly large amount for the cup, but that's more a product of the ratio that ManualLabor sets between them.