### PR TITLE
Add Filling Bar to Fluid Container Items

### DIFF
--- a/src/main/java/org/terasology/fluid/system/FluidClientSystem.java
+++ b/src/main/java/org/terasology/fluid/system/FluidClientSystem.java
@@ -151,12 +151,11 @@ public class FluidClientSystem extends BaseComponentSystem {
         int minY = (int) (size.y * 0.1f);
         int maxY = (int) (size.y * 0.9f);
 
-        float fillingPercentage = 1f * fluidContainer.volume / fluidContainer.maxVolume;
+        float fillingPercentage = fluidContainer.volume / fluidContainer.maxVolume;
 
-        if (fillingPercentage != 1f) {
+        if (fillingPercentage > 0f && fillingPercentage < 1f) {
             ResourceUrn backgroundTexture = TextureUtil.getTextureUriForColor(Color.WHITE);
-            final Color terasologyColor = getTerasologyColorForFilledAmount(fillingPercentage);
-            ResourceUrn barTexture = TextureUtil.getTextureUriForColor(terasologyColor);
+            ResourceUrn barTexture = TextureUtil.getTextureUriForColor(Color.BLUE);
 
             canvas.drawTexture(Assets.get(backgroundTexture, Texture.class).get(), Rect2i.createFromMinAndMax(minX,
                     minY, maxX, maxY));
@@ -165,10 +164,5 @@ public class FluidClientSystem extends BaseComponentSystem {
             canvas.drawTexture(Assets.get(barTexture, Texture.class).get(), Rect2i.createFromMinAndSize(minX + 1,
                     maxY - fillingBarHeight - 1, fillingBarLength, fillingBarHeight ));
         }
-    }
-
-    private Color getTerasologyColorForFilledAmount(float fillingPercentage) {
-        final java.awt.Color awtColor = java.awt.Color.getHSBColor(0.33f * fillingPercentage, 1f, 0.8f);
-        return new Color(awtColor.getRed(), awtColor.getGreen(), awtColor.getBlue());
     }
 }

--- a/src/main/java/org/terasology/fluid/system/FluidClientSystem.java
+++ b/src/main/java/org/terasology/fluid/system/FluidClientSystem.java
@@ -140,38 +140,35 @@ public class FluidClientSystem extends BaseComponentSystem {
      */
     @ReceiveEvent
     public void drawFillingBarForFluidContainerItem(InventoryCellRendered event, EntityRef entity,
-                               FluidContainerItemComponent fluidContainer) {
+                                                    FluidContainerItemComponent fluidContainer) {
         Canvas canvas = event.getCanvas();
 
         Vector2i size = canvas.size();
 
-        int minX = (int) (size.x * 0.1f);
+        int minX = (int) (size.x * 0.8f);
         int maxX = (int) (size.x * 0.9f);
 
-        int minY = (int) (size.y * 0.8f);
+        int minY = (int) (size.y * 0.1f);
         int maxY = (int) (size.y * 0.9f);
 
         float fillingPercentage = 1f * fluidContainer.volume / fluidContainer.maxVolume;
 
         if (fillingPercentage != 1f) {
             ResourceUrn backgroundTexture = TextureUtil.getTextureUriForColor(Color.WHITE);
-
             final Color terasologyColor = getTerasologyColorForFilledAmount(fillingPercentage);
-
             ResourceUrn barTexture = TextureUtil.getTextureUriForColor(terasologyColor);
 
             canvas.drawTexture(Assets.get(backgroundTexture, Texture.class).get(), Rect2i.createFromMinAndMax(minX,
                     minY, maxX, maxY));
-            int fillingBarLength = (int) (fillingPercentage * (maxX - minX - 1));
-            int fillingBarHeight = maxY - minY - 1;
+            int fillingBarHeight = (int) (fillingPercentage * (maxY - minY - 1));
+            int fillingBarLength = maxX - minX - 1;
             canvas.drawTexture(Assets.get(barTexture, Texture.class).get(), Rect2i.createFromMinAndSize(minX + 1,
-                    minY + 1, fillingBarLength, fillingBarHeight));
+                    maxY - fillingBarHeight - 1, fillingBarLength, fillingBarHeight ));
         }
     }
 
     private Color getTerasologyColorForFilledAmount(float fillingPercentage) {
         final java.awt.Color awtColor = java.awt.Color.getHSBColor(0.33f * fillingPercentage, 1f, 0.8f);
-
         return new Color(awtColor.getRed(), awtColor.getGreen(), awtColor.getBlue());
     }
 }


### PR DESCRIPTION
The PR adds a Filling Amount Bar over the fluid container item in the inventory.

![image](https://user-images.githubusercontent.com/29981695/87822387-aa2a9b00-c871-11ea-9631-1c436e2cd191.png)

To test: 
Since as of now, fluid containers are directly completely filled, following can be used to test:
1.temporarily change prefab of items to change current volume of the containers.
OR
2.Activate IRLCorp module, use fluidTank, woodenBucket, woodenCup to fill in varying amounts.. for eg. fill tank with bucket(+1000)
remove some using woodenCup(-300) = Net +700,  fill woodenBucket to see the partially filled bar.