### PR TITLE
feat: Enable placement of liquids from containers

### DIFF
--- a/src/main/java/org/terasology/fluid/system/FluidContainerAssetResolver.java
+++ b/src/main/java/org/terasology/fluid/system/FluidContainerAssetResolver.java
@@ -149,6 +149,13 @@ public class FluidContainerAssetResolver implements AssetDataProducer<TextureDat
                 || !(assetName.startsWith("fluiditem(") || assetName.startsWith("fluidbase("))) {
             return Optional.empty();
         }
+
+        FluidRegistry fluidRegistry = CoreRegistry.get(FluidRegistry.class);
+        if (fluidRegistry == null) {
+            // Sometimes in multiplayer it loads things involving assets from the server before the systems are initialized.
+            return Optional.empty();
+        }
+
         boolean isItem = assetName.startsWith("fluiditem");
         String[] split = assetName.split("\\(");
 
@@ -189,7 +196,10 @@ public class FluidContainerAssetResolver implements AssetDataProducer<TextureDat
             String textureWithHole = parameters[0];
             String fluidType = parameters[1];
 
-            BufferedImage fluidTexture = CoreRegistry.get(FluidRegistry.class).getFluidTexture(fluidType);
+            BufferedImage fluidTexture = fluidRegistry.getFluidTexture(fluidType);
+            if (fluidTexture == null) {
+                return Optional.empty();
+            }
 
             Optional<TextureRegionAsset> textureWithHoleRegion = assetManager.getAsset(textureWithHole,
                     TextureRegionAsset.class);
@@ -226,7 +236,10 @@ public class FluidContainerAssetResolver implements AssetDataProducer<TextureDat
         } else {
             String fluidType = parameters[0];
 
-            result = CoreRegistry.get(FluidRegistry.class).getFluidTexture(fluidType);
+            result = fluidRegistry.getFluidTexture(fluidType);
+            if (result == null) {
+                return Optional.empty();
+            }
         }
 
         final ByteBuffer resultBuffer = TextureUtil.convertToByteBuffer(result);


### PR DESCRIPTION
Re-bind picking up liquids with containers to attack (mouse 1), enable placement with activate (mouse 2, formerly pick up liquids), and fix a multiplayer bug relating to creating container images. Fluids registered without a corresponding liquid block (like steam) just can't be placed (except, using the Machines module, in tanks). Liquids can be placed from containers on solid blocks as usual as well as on other liquids.

The AttackEvent, which would usually be activated by mouse button 1, isn't suitable in itself because they're only triggered when there's a target in range to attack, and liquids don't count, so the earlier lower-level AttackRequest event is used instead. This means that I had to re-implement some things from the character system in the FluidAuthoritySystem instead (specifically, part of `fillFluidContainerItem` is based on `CharacterSystem.onAttackRequest`), but with liquids added to the list of targetable things, and I'm not entirely sure I did this correctly with respect to what's meant to happen on the client vs the server. It seems to work though.

In order to test that it was working correctly in multiplayer, I had to also fix an unrelated multiplayer bug. That's the changes to `FluidContainerAssetResolver`.

Machines needs a slight update to avoid placing liquids at the same time as putting fluids in tanks in some cases.

That issue seems to cover a few different things, but I think this resolves #10.