### PR TITLE
Reduce the priority for placing fluids

### DIFF
--- a/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
+++ b/src/main/java/org/terasology/fluid/system/FluidAuthoritySystem.java
@@ -212,7 +212,7 @@ public class FluidAuthoritySystem extends BaseComponentSystem {
      * @param item           the item they're holding at the time
      * @param fluidContainer the FluidContainerItemComponent of the item
      */
-    @ReceiveEvent
+    @ReceiveEvent(priority = EventPriority.PRIORITY_TRIVIAL)
     public void emptyFluidContainerItem(ActivateEvent event, EntityRef item, FluidContainerItemComponent fluidContainer) {
         CharacterComponent characterComponent = event.getInstigator().getComponent(CharacterComponent.class);
         if (fluidContainer.fluidType == null || characterComponent == null) {


### PR DESCRIPTION
Set the priority for placing liquids to lower than the priority for drinking. This means that if the player is holding a container of drinkable liquid, and the container is suitable for drinking from, they can't place it, but if it isn't drinkable (e.g. it's a bucket of water, or a cup of lava), they still can place it.